### PR TITLE
Update to serde 0.6.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ install_requires = [
     'cryptography >=2.0.0, <3.0.0',
     'pyperclip >=1.0.0, <2.0.0',
     'requests >=2.0.0, <3.0.0',
-    'serde[ext,toml] >=0.5.1, <0.6.0',
+    'serde[ext,toml] >=0.6.1, <0.7.0',
     'tabulate >=0.8.0, <0.9.0'
 ]
 entry_points = {

--- a/src/passthesalt/__init__.py
+++ b/src/passthesalt/__init__.py
@@ -2,11 +2,6 @@
 PassTheSalt is a deterministic password generation and password storage system.
 """
 
-from passthesalt.core import (
-    Algorithm, Config, Encrypted, Generatable, Login, Master, PassTheSalt, Secret
-)
-
-
 __all__ = [
     'Algorithm',
     'Config',
@@ -26,3 +21,8 @@ __author__ = 'Ross MacArthur'
 __author_email__ = 'ross@macarthur.io'
 __license__ = 'MIT'
 __description__ = 'Deterministic password generation and password storage.'
+
+
+from passthesalt.core import (
+    Algorithm, Config, Encrypted, Generatable, Login, Master, PassTheSalt, Secret
+)

--- a/src/passthesalt/__init__.py
+++ b/src/passthesalt/__init__.py
@@ -2,6 +2,19 @@
 PassTheSalt is a deterministic password generation and password storage system.
 """
 
+__title__ = 'passthesalt'
+__version__ = '3.1.0'
+__url__ = 'https://github.com/rossmacarthur/passthesalt'
+__author__ = 'Ross MacArthur'
+__author_email__ = 'ross@macarthur.io'
+__license__ = 'MIT'
+__description__ = 'Deterministic password generation and password storage.'
+
+from passthesalt.core import (
+    Algorithm, Config, Encrypted, Generatable, Login, Master, PassTheSalt, Secret
+)
+
+
 __all__ = [
     'Algorithm',
     'Config',
@@ -11,18 +24,6 @@ __all__ = [
     'Master',
     'PassTheSalt',
     'Secret',
-    'error',
+    'exceptions',
     'remote'
 ]
-__title__ = 'passthesalt'
-__version__ = '3.1.0'
-__url__ = 'https://github.com/rossmacarthur/passthesalt'
-__author__ = 'Ross MacArthur'
-__author_email__ = 'ross@macarthur.io'
-__license__ = 'MIT'
-__description__ = 'Deterministic password generation and password storage.'
-
-
-from passthesalt.core import (
-    Algorithm, Config, Encrypted, Generatable, Login, Master, PassTheSalt, Secret
-)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,15 +1,11 @@
 import datetime
 import string
 import tempfile
-from unittest import mock
 
 import serde
 from pytest import raises
 
-from passthesalt import __version__
-from passthesalt.core import (
-    Config, Encrypted, Generatable, Login, Master, PassTheSalt, Secret, version
-)
+from passthesalt.core import Config, Encrypted, Generatable, Login, Master, PassTheSalt, Secret
 from passthesalt.exceptions import ConfigurationError, ContextError, LabelError
 
 
@@ -17,17 +13,11 @@ class SecretSub(Secret):
     pass
 
 
-def test_version():
-    assert version() == __version__
-
-
-@mock.patch.dict('passthesalt.core.SECRETS', {'secret': SecretSub})
-@mock.patch.dict('passthesalt.core.KINDS', {SecretSub: 'secret'})
 class TestSecret:
 
     def test_from_dict(self):
         given = {
-            'kind': 'secret',
+            'kind': 'secretsub',
             'modified': '2017-12-29'
         }
         expected = SecretSub(
@@ -47,17 +37,10 @@ class TestSecret:
             modified=datetime.datetime(year=2017, month=12, day=29)
         )
         expected = {
-            'kind': 'secret',
+            'kind': 'secretsub',
             'modified': '2017-12-29'
         }
         assert given.to_dict() == expected
-
-    def test_to_dict_unknown_kind(self):
-        class SecretSub2(Secret):
-            pass
-
-        with raises(serde.exceptions.SerializationError):
-            SecretSub2().to_dict()
 
     def test___getattr__(self):
         example = Secret()
@@ -74,7 +57,7 @@ class TestSecret:
     def test_display(self):
         example = SecretSub()
         example.add_context('example', object())
-        assert example.display() == ('example', 'secret', example.modified)
+        assert example.display() == ('example', 'secretsub', example.modified)
 
     def test_add_context(self):
         example = SecretSub()


### PR DESCRIPTION
Serde 0.6.x now supports Model tagging, so we can use that instead of rolling our own.